### PR TITLE
analyse: add unreachable-code rule and cache/sync rule registry

### DIFF
--- a/analyse/rules.go
+++ b/analyse/rules.go
@@ -3,6 +3,7 @@ package analyse
 import (
 	"go-phpcs/ast"
 	"sort"
+	"sync"
 )
 
 type AnalysisIssue struct {
@@ -16,35 +17,64 @@ type AnalysisIssue struct {
 type AnalysisRuleFunc func(filename string, nodes []ast.Node) []AnalysisIssue
 
 var (
-	analysisRuleRegistry = map[string]AnalysisRuleFunc{}
+	analysisRuleRegistry     = map[string]AnalysisRuleFunc{}
+	analysisRuleRegistryLock sync.RWMutex
+	sortedRuleCodesCache     []string
+	sortedRuleCodesDirty     = true
 )
 
 func RegisterAnalysisRule(code string, fn AnalysisRuleFunc) {
+	analysisRuleRegistryLock.Lock()
+	defer analysisRuleRegistryLock.Unlock()
+
 	analysisRuleRegistry[code] = fn
+	sortedRuleCodesDirty = true
 }
 
 // ListRegisteredAnalysisRuleCodes returns registered analysis rule codes in sorted order.
 func ListRegisteredAnalysisRuleCodes() []string {
-	codes := make([]string, 0, len(analysisRuleRegistry))
-	for c := range analysisRuleRegistry {
-		codes = append(codes, c)
+	analysisRuleRegistryLock.RLock()
+	if !sortedRuleCodesDirty {
+		codes := append([]string(nil), sortedRuleCodesCache...)
+		analysisRuleRegistryLock.RUnlock()
+		return codes
 	}
-	sort.Strings(codes)
-	return codes
+	analysisRuleRegistryLock.RUnlock()
+
+	analysisRuleRegistryLock.Lock()
+	defer analysisRuleRegistryLock.Unlock()
+
+	if sortedRuleCodesDirty {
+		codes := make([]string, 0, len(analysisRuleRegistry))
+		for c := range analysisRuleRegistry {
+			codes = append(codes, c)
+		}
+		sort.Strings(codes)
+		sortedRuleCodesCache = codes
+		sortedRuleCodesDirty = false
+	}
+
+	return append([]string(nil), sortedRuleCodesCache...)
 }
 
 // ClearAnalysisRules removes all registered analysis rules. Useful for test isolation.
 func ClearAnalysisRules() {
+	analysisRuleRegistryLock.Lock()
+	defer analysisRuleRegistryLock.Unlock()
+
 	for k := range analysisRuleRegistry {
 		delete(analysisRuleRegistry, k)
 	}
+	sortedRuleCodesCache = nil
+	sortedRuleCodesDirty = true
 }
 
 func RunAnalysisRules(filename string, nodes []ast.Node) []AnalysisIssue {
-	// Ensure deterministic execution order for testability and reproducibility.
 	codes := ListRegisteredAnalysisRuleCodes()
 
 	issues := make([]AnalysisIssue, 0, 8)
+	analysisRuleRegistryLock.RLock()
+	defer analysisRuleRegistryLock.RUnlock()
 	for _, code := range codes {
 		fn := analysisRuleRegistry[code]
 		issues = append(issues, fn(filename, nodes)...)

--- a/analyse/unreachable_code_rule.go
+++ b/analyse/unreachable_code_rule.go
@@ -1,0 +1,80 @@
+package analyse
+
+import "go-phpcs/ast"
+
+// UnreachableCodeRule reports statements that can never execute because a
+// previous statement in the same block always terminates control flow.
+//
+// Inspired by modern static analyzers (like mago), this keeps the check cheap by
+// performing a single pass per block and short-circuiting once a terminator is found.
+type UnreachableCodeRule struct{}
+
+func (r *UnreachableCodeRule) CheckIssues(nodes []ast.Node, filename string) []AnalysisIssue {
+	issues := make([]AnalysisIssue, 0, 4)
+	r.walkStatements(nodes, filename, &issues)
+	return issues
+}
+
+func (r *UnreachableCodeRule) walkStatements(stmts []ast.Node, filename string, issues *[]AnalysisIssue) {
+	terminated := false
+	for _, stmt := range stmts {
+		if terminated {
+			pos := stmt.GetPos()
+			*issues = append(*issues, AnalysisIssue{
+				Filename: filename,
+				Line:     pos.Line,
+				Column:   pos.Column,
+				Code:     "Generic.CodeAnalysis.UnreachableCode",
+				Message:  "Unreachable statement after terminating statement",
+			})
+			continue
+		}
+
+		r.walkChildren(stmt, filename, issues)
+		if isTerminatingStatement(stmt) {
+			terminated = true
+		}
+	}
+}
+
+func (r *UnreachableCodeRule) walkChildren(node ast.Node, filename string, issues *[]AnalysisIssue) {
+	switch n := node.(type) {
+	case *ast.FunctionNode:
+		r.walkStatements(n.Body, filename, issues)
+	case *ast.ClassNode:
+		for _, m := range n.Methods {
+			r.walkChildren(m, filename, issues)
+		}
+	case *ast.BlockNode:
+		r.walkStatements(n.Statements, filename, issues)
+	case *ast.IfNode:
+		r.walkStatements(n.Body, filename, issues)
+		for _, elseif := range n.ElseIfs {
+			r.walkStatements(elseif.Body, filename, issues)
+		}
+		if n.Else != nil {
+			r.walkStatements(n.Else.Body, filename, issues)
+		}
+	case *ast.WhileNode:
+		r.walkStatements(n.Body, filename, issues)
+	case *ast.ForeachNode:
+		r.walkStatements(n.Body, filename, issues)
+	case *ast.NamespaceNode:
+		r.walkStatements(n.Body, filename, issues)
+	}
+}
+
+func isTerminatingStatement(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.ReturnNode, *ast.ThrowNode:
+		return true
+	}
+	return false
+}
+
+func init() {
+	RegisterAnalysisRule("Generic.CodeAnalysis.UnreachableCode", func(filename string, nodes []ast.Node) []AnalysisIssue {
+		rule := &UnreachableCodeRule{}
+		return rule.CheckIssues(nodes, filename)
+	})
+}

--- a/analyse/unreachable_code_rule_test.go
+++ b/analyse/unreachable_code_rule_test.go
@@ -1,0 +1,84 @@
+package analyse
+
+import (
+	"go-phpcs/lexer"
+	"go-phpcs/parser"
+	"testing"
+)
+
+func analyseUnreachablePHP(t *testing.T, code string) []AnalysisIssue {
+	t.Helper()
+	l := lexer.New(code)
+	p := parser.New(l, false)
+	nodes := p.Parse()
+	if len(p.Errors()) > 0 {
+		t.Fatalf("parser errors: %v", p.Errors())
+	}
+	rule := &UnreachableCodeRule{}
+	return rule.CheckIssues(nodes, "test.php")
+}
+
+func countUnreachableIssues(issues []AnalysisIssue) int {
+	count := 0
+	for _, issue := range issues {
+		if issue.Code == "Generic.CodeAnalysis.UnreachableCode" {
+			count++
+		}
+	}
+	return count
+}
+
+func TestUnreachableAfterReturnInFunction(t *testing.T) {
+	php := `<?php
+function foo(): int {
+    return 1;
+    $x = 2;
+}`
+	issues := analyseUnreachablePHP(t, php)
+	if got := countUnreachableIssues(issues); got != 1 {
+		t.Fatalf("expected 1 unreachable issue, got %d (%#v)", got, issues)
+	}
+}
+
+func TestUnreachableAfterThrowInFunction(t *testing.T) {
+	php := `<?php
+function foo(): int {
+    throw $e;
+    return 1;
+}`
+	issues := analyseUnreachablePHP(t, php)
+	if got := countUnreachableIssues(issues); got != 1 {
+		t.Fatalf("expected 1 unreachable issue, got %d (%#v)", got, issues)
+	}
+}
+
+func TestReachableAcrossBranchesNotReported(t *testing.T) {
+	php := `<?php
+function foo($x): int {
+    if ($x) {
+        return 1;
+    }
+
+    return 2;
+}`
+	issues := analyseUnreachablePHP(t, php)
+	if got := countUnreachableIssues(issues); got != 0 {
+		t.Fatalf("expected 0 unreachable issues, got %d (%#v)", got, issues)
+	}
+}
+
+func TestUnreachableInsideIfBranch(t *testing.T) {
+	php := `<?php
+function foo($x): int {
+    if ($x) {
+        return 1;
+        $a = 1;
+    }
+
+    return 2;
+}`
+	issues := analyseUnreachablePHP(t, php)
+	if got := countUnreachableIssues(issues); got != 1 {
+		t.Fatalf("expected 1 unreachable issue, got %d (%#v)", got, issues)
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a cheap, useful control-flow lint that detects statements rendered unreachable by earlier terminating statements, inspired by modern analysers like mago. 
- Reduce per-file overhead when dispatching analysis rules by avoiding repeated sorting and by making the registry concurrency-safe. 

### Description
- Add a new analysis rule `Generic.CodeAnalysis.UnreachableCode` in `analyse/unreachable_code_rule.go` that walks blocks and reports statements after `return` or `throw`. 
- Add focused tests in `analyse/unreachable_code_rule_test.go` covering unreachable-after-return, unreachable-after-throw, branch-safe scenarios, and unreachable inside conditional branches. 
- Rewrite `analyse/rules.go` to introduce `sync.RWMutex` protection for the rule registry and a cached, invalidated-on-change sorted rule-code list to avoid sorting on every `RunAnalysisRules` invocation. 

### Testing
- Formatted modified files with `gofmt -w analyse/rules.go analyse/unreachable_code_rule.go analyse/unreachable_code_rule_test.go`. (succeeded) 
- Ran unit tests for the analyse package with `go test ./analyse/...` and verified they passed. (succeeded) 
- Ran full project tests with `go test ./...` and verified all packages with tests passed. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8ed4832488320b47f39c0a87b2e71)